### PR TITLE
Nicer (single) msg when no posts found.

### DIFF
--- a/jquery.ghostrelated.js
+++ b/jquery.ghostrelated.js
@@ -45,6 +45,11 @@
                     }
                     count++;
                 });
+
+                if (count == 0) {
+                    $(that.element).append($('<p>No related posts were found. ' +
+                        'Check the <a href="/">index</a>.</p>'));
+                }
             })
             .fail(function(e) {
                 that.reportError(e);
@@ -146,11 +151,8 @@
 
 
     RelatedPosts.prototype.reportError = function(error) {
-
         if (this.options.debug) {
             $(this.element).append($('<li>' + error + '</li>'));
-        } else {
-            $(this.element).append($('<li>No related posts were found.</li>'));
         }
     };
 


### PR DESCRIPTION
If a post has no tags the current version of the plugin will output that nothing was found twice. This change makes sense for my use case at least. If it makes sense for yours as well, feel free to accept this PR. :)

Great work on the plugin!
